### PR TITLE
Add App Engine deploy version

### DIFF
--- a/deployment/appengine-web/build.gradle
+++ b/deployment/appengine-web/build.gradle
@@ -65,6 +65,7 @@ configurations.all({
 
 appengine {
     deploy.projectId = 'spine-todo-list-example'
+    deploy.version = '1.6.0'
     run {
         port = 8080
         jvmFlags = ['-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005']


### PR DESCRIPTION
It's now necessary to manually specify the deployed app version in the App Engine Gradle Plugin.

This PR adds it so the `:appengineDeploy` task passes on CI.