### PR TITLE
Use auto-generated App Engine deploy version

### DIFF
--- a/deployment/appengine-web/build.gradle
+++ b/deployment/appengine-web/build.gradle
@@ -65,7 +65,7 @@ configurations.all({
 
 appengine {
     deploy.projectId = 'spine-todo-list-example'
-    deploy.version = '1.6.0'
+    deploy.version = 'GCLOUD_CONFIG'
     run {
         port = 8080
         jvmFlags = ['-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005']


### PR DESCRIPTION
In #168, we specified an App Engine deploy version which is incorrect.

In this PR, we update the config to use an auto-generated deploy version to avoid such problems in the future.